### PR TITLE
Make the hid argument of the ipf function less error prone

### DIFF
--- a/R/ipf.r
+++ b/R/ipf.r
@@ -579,8 +579,8 @@ ipf <- function(
   } else {
     if (!is.factor(dat[[hid]]))
       data.table::set(dat, NULL, hid, as.factor(dat[[hid]]))
-    dat[, representativeHouseholdForCalibration :=
-          as.numeric(!duplicated(get(hid)))]
+    rh <- as.numeric(!duplicated(dat[[hid]]))
+    dat[, representativeHouseholdForCalibration := rh]
   }
 
   ## Names of the calibration variables for Person and household dimension


### PR DESCRIPTION
In the case that household id is "hid", specifying the hid argument of the ipf function as that can cause an error.

``` r
library(surveysd)
# load data
eusilc <- demo.eusilc(n = 1, prettyNames = TRUE)

# personal constraints
conP1 <- xtabs(pWeight ~ age, data = eusilc)
conP2 <- xtabs(pWeight ~ gender + region, data = eusilc)
conP3 <- xtabs(pWeight*eqIncome ~ gender, data = eusilc)

# household constraints
conH1 <- xtabs(pWeight ~ hsize + region, data = eusilc)

# create an initial weight for the calibration
eusilc[, regSamp := .N, by = region]
eusilc[, regPop := sum(pWeight), by = region]
eusilc[, baseWeight := regPop/regSamp]

calibweights <- ipf(
  eusilc,
  conP = list(conP1, conP2),
  conH = list(conH1),
  w = "baseWeight",
  verbose = TRUE,
  hid = "hid"
)
#> Error in get(hid): invalid first argument
```

<sup>Created on 2019-12-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

```r
R version 3.6.1 (2019-07-05)
Platform: x86_64-apple-darwin15.6.0 (64-bit)
Running under: macOS Mojave 10.14.6

Matrix products: default
BLAS:   /System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/Versions/A/libBLAS.dylib
LAPACK: /Library/Frameworks/R.framework/Versions/3.6/Resources/lib/libRlapack.dylib

locale:
[1] en_AU.UTF-8/en_AU.UTF-8/en_AU.UTF-8/C/en_AU.UTF-8/en_AU.UTF-8

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base     

other attached packages:
[1] surveysd_1.1.0     usethis_1.5.1.9000 colorout_1.2-2    

loaded via a namespace (and not attached):
 [1] Rcpp_1.0.3         pillar_1.4.2       compiler_3.6.1     tools_3.6.1        boot_1.3-23        digest_0.6.23      packrat_0.5.0      evaluate_0.14      lifecycle_0.1.0    tibble_2.1.3      
[11] gtable_0.3.0       pkgconfig_2.0.3    rlang_0.4.2        reprex_0.3.0       rstudioapi_0.10    xfun_0.11          dplyr_0.8.3        knitr_1.26.1       fs_1.3.1           grid_3.6.1        
[21] tidyselect_0.2.5   glue_1.3.1         data.table_1.12.8  R6_2.4.1           processx_3.4.1     rmarkdown_2.0      laeken_0.5.0       clipr_0.7.0        callr_3.4.0        ggplot2_3.2.1     
[31] purrr_0.3.3        magrittr_1.5       whisker_0.4        ps_1.3.0           scales_1.1.0       matrixStats_0.55.0 htmltools_0.4.0    MASS_7.3-51.4      assertthat_0.2.1   colorspace_1.4-1  
[41] lazyeval_0.2.2     munsell_0.5.0      crayon_1.3.4   
```